### PR TITLE
fix: Modify to use monthly half perfect user objects

### DIFF
--- a/src/pages/DashboardPage/MonthlyHalfPerfectUserTable.jsx
+++ b/src/pages/DashboardPage/MonthlyHalfPerfectUserTable.jsx
@@ -32,10 +32,11 @@ function MonthlyHalfPerfectUserTable(props) {
   const { data } = props;
   const rows = [];
   if (data.length > 0) {
-    data.forEach((intraId) => {
-      rows.push({intraId});
+    data.forEach((user) => {
+      rows.push({intraId: user.userInfo.intraId});
     });
   }
+
   return (
     <Grid item>
       <Card>

--- a/src/pages/DashboardPage/index.jsx
+++ b/src/pages/DashboardPage/index.jsx
@@ -53,14 +53,14 @@ function DashboardPage() {
       const responseMonthlyUsers = await apiManager.get(
         `/statistic/monthly-users/${dateQuery.queryYear}/${dateQuery.queryMonth}`
       );
-      const responseHalfPerfectUserIntraIds = await apiManager.get(
+      const responseHalfPerfectUsers = await apiManager.get(
         `/statistic/monthly-users/half-perfect/${dateQuery.queryYear}/${dateQuery.queryMonth}`
       );
       setMonthlyTotalUser(getMonthlyTotalUser(responseMonthlyUsers.data));
       setMonthlyPerfectUser(getMonthlyPerfectUser(responseMonthlyUsers.data));
-      setMonthlyHalfPerfectUser(getMonthlyHalfPerfectUser(responseHalfPerfectUserIntraIds.data));
+      setMonthlyHalfPerfectUser(getMonthlyHalfPerfectUser(responseHalfPerfectUsers.data));
       setMonthlyStatistic(responseMonthlyUsers.data);
-      setMonthlylHalfPerfectUserIntraIds(responseHalfPerfectUserIntraIds.data);
+      setMonthlylHalfPerfectUserIntraIds(responseHalfPerfectUsers.data);
       setResultDate({ year: dateQuery.queryYear, month: dateQuery.queryMonth });
     } catch (error) {
       setSnackbarOpen(true);


### PR DESCRIPTION
## 변경 사항

- 기존: 1/2 개근 유저 IntraId들이 담긴 string 배열 이용 -> **변경: 1/2 개근 유저 MonthlyUser Object 이용**

- 사유: `GET /statistic/monthly-users/half-perfect/{year}/{month}` API에서 넘겨주는 데이터의 형태가 `stirng[]`에서 `MonthlyUser[]`로 변경